### PR TITLE
Remove generation mode

### DIFF
--- a/include/chess.h
+++ b/include/chess.h
@@ -710,13 +710,6 @@ int is_legal_internal(const chess_state_t* chess_state, move_t move,
 // although this is not required and incremental legality checking is supported
 // and even encouraged
 
-enum generator_mode {
-  GENERATE_QUIETS = 1,
-  GENERATE_CAPTURES = 2,
-  GENERATE_PROMOTIONS = 4,
-  GENERATE_ALL = GENERATE_QUIETS | GENERATE_CAPTURES | GENERATE_PROMOTIONS,
-};
-
 // generates psuedo legal moves, is_legal test should be performed before move
 // is played.
 size_t generate_moves(const chess_state_t* chess_state, move_t* moves,

--- a/include/chess.h
+++ b/include/chess.h
@@ -14,7 +14,6 @@ extern "C" {
 #define TOP_BORDER 0
 #define MOVE_PRIORITY_MAX 0xFFF
 
-
 #define MAXSCORE ((centipawn_t)(INT16_MAX))
 #define MINSCORE ((centipawn_t)(-INT16_MAX))
 
@@ -23,7 +22,9 @@ extern "C" {
 #define BISHOP_SCORE ((centipawn_t)(330))
 #define ROOK_SCORE ((centipawn_t)(500))
 #define QUEEN_SCORE ((centipawn_t)(900))
-#define KING_SCORE ((centipawn_t)(KNIGHT_SCORE*2+BISHOP_SCORE*2+ROOK_SCORE*2+QUEEN_SCORE*9))
+#define KING_SCORE                                                      \
+  ((centipawn_t)(KNIGHT_SCORE * 2 + BISHOP_SCORE * 2 + ROOK_SCORE * 2 + \
+                 QUEEN_SCORE * 9))
 #define CHECKMATE_SCORE ((centipawn_t)(-16000))
 #define DRAW_SCORE ((centipawn_t)(0))
 
@@ -41,15 +42,31 @@ extern "C" {
 #endif
 
 #ifdef PRINT_READ_ERRORS
-#define READ_ERROR(msg, ...) {fprintf(stderr,"READ ERROR: reading \"%s\" ", buffer);fprintf(stderr, msg, ##__VA_ARGS__); return -1;}
+#define READ_ERROR(msg, ...)                                \
+  {                                                         \
+    fprintf(stderr, "READ ERROR: reading \"%s\" ", buffer); \
+    fprintf(stderr, msg, ##__VA_ARGS__);                    \
+    return -1;                                              \
+  }
 #else
-#define READ_ERROR(msg, ...) {return -1;}
+#define READ_ERROR(msg, ...) \
+  { return -1; }
 #endif
 
 #ifdef PRINT_WRITE_ERRORS
-#define WRITE_ERROR(msg, ...) {fprintf(stderr,"WRITE ERROR: ");printf(msg, ##__VA_ARGS__); buffer[0] = 0; return -1;}
+#define WRITE_ERROR(msg, ...)         \
+  {                                   \
+    fprintf(stderr, "WRITE ERROR: "); \
+    printf(msg, ##__VA_ARGS__);       \
+    buffer[0] = 0;                    \
+    return -1;                        \
+  }
 #else
-#define WRITE_ERROR(msg, ...) {buffer[0] = 0; return -1;}
+#define WRITE_ERROR(msg, ...) \
+  {                           \
+    buffer[0] = 0;            \
+    return -1;                \
+  }
 #endif
 
 // coordinates stored in 0x88 format
@@ -421,6 +438,17 @@ static inline uint8_t off_the_board(sq0x88_t sq0x88) {
   return sq0x88 & (uint8_t)0x88;
 }
 
+static inline rank07_t backrank(colour_t colour) {
+  switch (colour & COLOUR_MASK) {
+    case WHITE:
+      return 7;
+    case BLACK:
+      return 0;
+    default:
+      return 0;
+  }
+}
+
 // coordinate conversion funcitons
 
 static inline sq8x8_t sq0x88_to_sq8x8(sq0x88_t sq0x88) {
@@ -475,12 +503,13 @@ static inline move_t uncompress_move(compact_move_t compact_move) {
               compact_move >> 12);
 }
 
-static inline colour_t piece_colour(const chess_state_t* chess_state, sq0x88_t square) {
+static inline colour_t piece_colour(const chess_state_t* chess_state,
+                                    sq0x88_t square) {
   return (piece(chess_state, square) & COLOUR_MASK);
 }
 
-static inline int piece_is_colour(const chess_state_t* chess_state, sq0x88_t square,
-                    colour_t colour) {
+static inline int piece_is_colour(const chess_state_t* chess_state,
+                                  sq0x88_t square, colour_t colour) {
   return piece_colour(chess_state, square) == colour;
 }
 
@@ -499,33 +528,38 @@ static inline sq0x88_t pawn_push_increment(colour_t colour) {
   return (colour & WHITE) ? (sq0x88_t)(A2 - A1) : (sq0x88_t)(A1 - A2);
 }
 
-static inline const piece_list_t* get_piece_list(const chess_state_t* chess_state,
-                                   colour_t colour) {
+static inline const piece_list_t* get_piece_list(
+    const chess_state_t* chess_state, colour_t colour) {
   return (colour & WHITE) ? &chess_state->white_pieces
                           : &chess_state->black_pieces;
 }
 
-static inline int is_promoting(sq0x88_t from,
-                 colour_t colour) {
+static inline int is_promoting(sq0x88_t from, colour_t colour) {
   return (sq0x88_to_rank07(from) == 1 && colour == BLACK) ||
          (sq0x88_to_rank07(from) == 6 && colour == WHITE);
 }
 
-static inline int pawn_can_double_push(sq0x88_t from,
-                         colour_t colour) {
+static inline int pawn_can_double_push(sq0x88_t from, colour_t colour) {
   return (sq0x88_to_rank07(from) == 6 && colour == BLACK) ||
          (sq0x88_to_rank07(from) == 1 && colour == WHITE);
 }
 
 static inline centipawn_t value_of(piece_t piece) {
-  switch(piece & PIECE_MASK) {
-    case PAWN: return PAWN_SCORE;
-    case KNIGHT: return KNIGHT_SCORE;
-    case BISHOP: return BISHOP_SCORE;
-    case ROOK: return ROOK_SCORE;
-    case QUEEN: return QUEEN_SCORE;
-    case KING: return KING_SCORE;
-    default: return 0;
+  switch (piece & PIECE_MASK) {
+    case PAWN:
+      return PAWN_SCORE;
+    case KNIGHT:
+      return KNIGHT_SCORE;
+    case BISHOP:
+      return BISHOP_SCORE;
+    case ROOK:
+      return ROOK_SCORE;
+    case QUEEN:
+      return QUEEN_SCORE;
+    case KING:
+      return KING_SCORE;
+    default:
+      return 0;
   }
 }
 
@@ -540,7 +574,8 @@ sq0x88_t knight_increment(sq0x88_t from, sq0x88_t to);
 sq0x88_t king_increment(sq0x88_t from, sq0x88_t to);
 
 // returns true if the players piece at square can be pseudo captured
-int is_under_attack(const chess_state_t* chess_state, sq0x88_t square, piece_t player);
+int is_under_attack(const chess_state_t* chess_state, sq0x88_t square,
+                    piece_t player);
 
 // returns true if there is atleast one piece threatening the king
 int is_check(const chess_state_t* chess_state);
@@ -592,8 +627,7 @@ long read_algebraic_notation(const char* buffer, long buffer_size,
 
 // write to buffer in long algebraic notation
 // e.g. e7e8Q or e1b3
-long write_long_algebraic_notation(char* buffer, long buffer_size,
-                                   move_t move);
+long write_long_algebraic_notation(char* buffer, long buffer_size, move_t move);
 // read from buffer a move in long algebraic notation
 // e.g. e7e8Q or e1b3
 long read_long_algebraic_notation(const char* buffer, long buffer_size,
@@ -616,10 +650,10 @@ long write_movetext_debug(char* buffer, long buffer_size,
 // writes the pgn out to a buffer
 // event, site, date, round, names, and fen are all optional parameters, if set
 // to NULL they will be left empty in pgn.
-long write_pgn(char* buffer, long buffer_size,
-               const chess_state_t* chess_state, const char* event,
-               const char* site, const char* date, const char* round,
-               const char* white_name, const char* black_name, const char* fen);
+long write_pgn(char* buffer, long buffer_size, const chess_state_t* chess_state,
+               const char* event, const char* site, const char* date,
+               const char* round, const char* white_name,
+               const char* black_name, const char* fen);
 
 // loads default chess starting position
 void load_start_position(chess_state_t* chess_state);
@@ -683,19 +717,23 @@ enum generator_mode {
   GENERATE_ALL = GENERATE_QUIETS | GENERATE_CAPTURES | GENERATE_PROMOTIONS,
 };
 
-// generates psuedo legal moves, is_legal test should be performed before move is played.
+// generates psuedo legal moves, is_legal test should be performed before move
+// is played.
 size_t generate_moves(const chess_state_t* chess_state, move_t* moves,
                       colour_t colour);
 
-// generates psuedo legal capturing moves, is_legal test should be performed before move is played.
+// generates psuedo legal capturing moves, is_legal test should be performed
+// before move is played.
 size_t generate_captures(const chess_state_t* chess_state, move_t* moves,
                          colour_t colour);
-                  
-// generates psuedo legal quiet moves, is_legal test should be performed before move is played.
+
+// generates psuedo legal quiet moves, is_legal test should be performed before
+// move is played.
 size_t generate_quiets(const chess_state_t* chess_state, move_t* moves,
                        colour_t colour);
 
-// generates psuedo legal promoting moves, is_legal test should be performed before move is played.
+// generates psuedo legal promoting moves, is_legal test should be performed
+// before move is played.
 size_t generate_promotions(const chess_state_t* chess_state, move_t* moves,
                            colour_t colour);
 
@@ -708,17 +746,12 @@ size_t generate_legal_quiets(const chess_state_t* chess_state, move_t* moves,
 size_t generate_legal_promotions(const chess_state_t* chess_state,
                                  move_t* moves, colour_t colour);
 
-size_t generate_moves_internal(const chess_state_t* chess_state, move_t* moves,
-                               colour_t colour,
-                               enum generator_mode generation_mode);
 
 size_t generate_moves_nocheck_internal(const chess_state_t* chess_state,
-                                       move_t* moves, colour_t colour,
-                                       enum generator_mode generation_mode);
+                                       move_t* moves, colour_t colour);
 
 size_t generate_moves_check_internal(const chess_state_t* chess_state,
-                                     move_t* moves, colour_t colour,
-                                     enum generator_mode generation_mode);
+                                     move_t* moves, colour_t colour);
 
 // zobrist own inverse function to incrementally update the running zobrist hash
 // of the current position
@@ -728,7 +761,8 @@ zobrist_t zobrist_flip_turn(zobrist_t zobrist);
 // of the current position
 zobrist_t zobrist_flip_piece(zobrist_t zobrist, piece_t piece, sq0x88_t square);
 
-// checks if the position is drawn by any of draw by repetition, draw by insufficient material, or draw by 50 move rule
+// checks if the position is drawn by any of draw by repetition, draw by
+// insufficient material, or draw by 50 move rule
 int is_draw(const chess_state_t* chess_state);
 
 // checks for 3 fold repetition
@@ -796,18 +830,14 @@ void place_piece(chess_state_t* chess_state, sq0x88_t target, piece_t piece);
 
 void move_piece(chess_state_t* chess_state, sq0x88_t from, sq0x88_t to);
 
-
 size_t knight_moves(const chess_state_t* chess_state, move_t* moves,
-                    size_t move_count, sq0x88_t from, colour_t colour,
-                    enum generator_mode generation_mode);
+                    size_t move_count, sq0x88_t from, colour_t colour);
 
 size_t king_moves(const chess_state_t* chess_state, move_t* moves,
-                  size_t move_count, sq0x88_t king_square, colour_t colour,
-                  enum generator_mode generation_mode);
+                  size_t move_count, sq0x88_t king_square, colour_t colour);
 
 size_t castling_moves(const chess_state_t* chess_state, move_t* moves,
-                      size_t move_count, sq0x88_t king_square, colour_t colour,
-                      enum generator_mode generation_mode);
+                      size_t move_count, sq0x88_t king_square, colour_t colour);
 
 // flags should either be QUIET_MOVE or CAPTURE, add_promotion_moves will handle
 // the promotion flags
@@ -815,21 +845,19 @@ size_t add_promotion_moves(move_t* moves, size_t move_count, sq0x88_t from,
                            sq0x88_t to, int flags);
 
 size_t pawn_moves(const chess_state_t* chess_state, move_t* moves,
-                  size_t move_count, sq0x88_t from, colour_t colour,
-                  enum generator_mode generation_mode);
+                  size_t move_count, sq0x88_t from, colour_t colour);
 
 size_t sliding_moves(const chess_state_t* chess_state, move_t* moves,
                      size_t move_count, sq0x88_t from, colour_t colour,
-                     enum generator_mode generation_mode,
                      const sq0x88_t* increments, int increments_count);
 
 size_t sliding_quiets(const chess_state_t* chess_state, move_t* moves,
-                     size_t move_count, sq0x88_t from, colour_t colour,
-                     const sq0x88_t* increments, int increments_count);
+                      size_t move_count, sq0x88_t from, colour_t colour,
+                      const sq0x88_t* increments, int increments_count);
 
 size_t sliding_captures(const chess_state_t* chess_state, move_t* moves,
-                     size_t move_count, sq0x88_t from, colour_t colour,
-                     const sq0x88_t* increments, int increments_count);
+                        size_t move_count, sq0x88_t from, colour_t colour,
+                        const sq0x88_t* increments, int increments_count);
 
 #ifdef __cplusplus
 }

--- a/src/game-over.c
+++ b/src/game-over.c
@@ -80,20 +80,20 @@ static const sq0x88_t rook_increments_list[ROOK_INCREMENTS_COUNT] = {1, 255,
 int is_stalemate(const chess_state_t* chess_state) {
   if (is_check(chess_state)) return 0;
   move_t moves[256];
-  size_t move_count = castling_moves(chess_state, moves, 0, chess_state->friendly_pieces->king_square, chess_state->friendly_colour, GENERATE_ALL);
+  size_t move_count = castling_moves(chess_state, moves, 0, chess_state->friendly_pieces->king_square, chess_state->friendly_colour);
   for (size_t i = 0; i < move_count; i++) {
     if (is_legal(chess_state, moves[i])) {
       return 0;
     }
   }
-  move_count = king_moves(chess_state, moves, 0, chess_state->friendly_pieces->king_square, chess_state->friendly_colour, GENERATE_ALL);
+  move_count = king_moves(chess_state, moves, 0, chess_state->friendly_pieces->king_square, chess_state->friendly_colour);
   for (size_t i = 0; i < move_count; i++) {
     if (is_legal(chess_state, moves[i])) {
       return 0;
     }
   }
   FOR_EACH_PIECE(chess_state->friendly_pieces, pawn, square) {
-    size_t move_count = pawn_moves(chess_state, moves, 0, square, chess_state->friendly_colour, GENERATE_ALL);
+    size_t move_count = pawn_moves(chess_state, moves, 0, square, chess_state->friendly_colour);
     for (size_t i = 0; i < move_count; i++) {
       if (is_legal(chess_state, moves[i])) {
         return 0;
@@ -102,7 +102,7 @@ int is_stalemate(const chess_state_t* chess_state) {
   }
 
   FOR_EACH_PIECE(chess_state->friendly_pieces, knight, square) {
-    size_t move_count = knight_moves(chess_state, moves, 0, square, chess_state->friendly_colour, GENERATE_ALL);
+    size_t move_count = knight_moves(chess_state, moves, 0, square, chess_state->friendly_colour);
     for (size_t i = 0; i < move_count; i++) {
       if (is_legal(chess_state, moves[i])) {
         return 0;
@@ -111,7 +111,7 @@ int is_stalemate(const chess_state_t* chess_state) {
   }
 
   FOR_EACH_PIECE(chess_state->friendly_pieces, light_bishop, square) {
-    size_t move_count = sliding_moves(chess_state, moves, 0, square, chess_state->friendly_colour, GENERATE_ALL, bishop_increments_list, BISHOP_INCREMENTS_COUNT);
+    size_t move_count = sliding_moves(chess_state, moves, 0, square, chess_state->friendly_colour, bishop_increments_list, BISHOP_INCREMENTS_COUNT);
     for (size_t i = 0; i < move_count; i++) {
       if (is_legal(chess_state, moves[i])) {
         return 0;
@@ -120,7 +120,7 @@ int is_stalemate(const chess_state_t* chess_state) {
   }
 
   FOR_EACH_PIECE(chess_state->friendly_pieces, dark_bishop, square) {
-    size_t move_count = sliding_moves(chess_state, moves, 0, square, chess_state->friendly_colour, GENERATE_ALL, bishop_increments_list, BISHOP_INCREMENTS_COUNT);
+    size_t move_count = sliding_moves(chess_state, moves, 0, square, chess_state->friendly_colour, bishop_increments_list, BISHOP_INCREMENTS_COUNT);
     for (size_t i = 0; i < move_count; i++) {
       if (is_legal(chess_state, moves[i])) {
         return 0;
@@ -129,7 +129,7 @@ int is_stalemate(const chess_state_t* chess_state) {
   }
 
   FOR_EACH_PIECE(chess_state->friendly_pieces, rook, square) {
-    size_t move_count = sliding_moves(chess_state, moves, 0, square, chess_state->friendly_colour, GENERATE_ALL, rook_increments_list, ROOK_INCREMENTS_COUNT);
+    size_t move_count = sliding_moves(chess_state, moves, 0, square, chess_state->friendly_colour, rook_increments_list, ROOK_INCREMENTS_COUNT);
     for (size_t i = 0; i < move_count; i++) {
       if (is_legal(chess_state, moves[i])) {
         return 0;
@@ -137,7 +137,7 @@ int is_stalemate(const chess_state_t* chess_state) {
     }
   }
   FOR_EACH_PIECE(chess_state->friendly_pieces, queen, square) {
-    size_t move_count = sliding_moves(chess_state, moves, 0, square, chess_state->friendly_colour, GENERATE_ALL, queen_increments_list, QUEEN_INCREMENTS_COUNT);
+    size_t move_count = sliding_moves(chess_state, moves, 0, square, chess_state->friendly_colour, queen_increments_list, QUEEN_INCREMENTS_COUNT);
     for (size_t i = 0; i < move_count; i++) {
       if (is_legal(chess_state, moves[i])) {
         return 0;

--- a/src/move_generation.c
+++ b/src/move_generation.c
@@ -26,10 +26,6 @@ static const sq0x88_t rook_increments_list[ROOK_INCREMENTS_COUNT] = {1, 255,
 // piece_lists, move_t* moves); make incremental move generation functions i.
 // size_t generate_captures(const chess_state_t* chess_state, move_t * moves);
 
-
-
-
-
 int can_capture_enpassent(const chess_state_t* chess_state, sq0x88_t from,
                           colour_t colour) {
   sq0x88_t inc = pawn_push_increment(colour);
@@ -62,48 +58,66 @@ int can_castle_queen_side(const chess_state_t* chess_state, colour_t colour) {
          piece(chess_state, king_square - 3) == EMPTY;
 }
 
-
-
-
-
-
-
 // knight movement
 
 size_t knight_moves(const chess_state_t* chess_state, move_t* moves,
-                    size_t move_count, sq0x88_t from, colour_t colour,
-                    enum generator_mode generation_mode) {
+                    size_t move_count, sq0x88_t from, colour_t colour) {
   for (int i = 0; i < KNIGHT_INCREMENTS_COUNT; i++) {
     sq0x88_t to = from + knight_increments_list[i];
     if (off_the_board(to) || piece_is_colour(chess_state, to, colour)) {
       continue;
     }
     piece_t target_piece = piece(chess_state, to);
-    if (target_piece == EMPTY && (generation_mode & GENERATE_QUIETS)) {
+    if (target_piece == EMPTY) {
       moves[move_count++] = move(from, to, QUIET_MOVE);
-    } else if (target_piece != EMPTY && (generation_mode & GENERATE_CAPTURES)) {
+    } else if (target_piece != EMPTY) {
       moves[move_count++] = move(from, to, CAPTURE);
     }
   }
   return move_count;
 }
 
+size_t knight_captures(const chess_state_t* chess_state, move_t* moves,
+                       size_t move_count, sq0x88_t from, colour_t colour) {
+  for (int i = 0; i < KNIGHT_INCREMENTS_COUNT; i++) {
+    sq0x88_t to = from + knight_increments_list[i];
+    if (off_the_board(to) || piece_is_colour(chess_state, to, colour)) {
+      continue;
+    }
+    piece_t target_piece = piece(chess_state, to);
+    if (target_piece != EMPTY) {
+      moves[move_count++] = move(from, to, CAPTURE);
+    }
+  }
+  return move_count;
+}
 
-
-
+size_t knight_quiets(const chess_state_t* chess_state, move_t* moves,
+                     size_t move_count, sq0x88_t from, colour_t colour) {
+  for (int i = 0; i < KNIGHT_INCREMENTS_COUNT; i++) {
+    sq0x88_t to = from + knight_increments_list[i];
+    if (off_the_board(to) || piece_is_colour(chess_state, to, colour)) {
+      continue;
+    }
+    piece_t target_piece = piece(chess_state, to);
+    if (target_piece == EMPTY) {
+      moves[move_count++] = move(from, to, QUIET_MOVE);
+    }
+  }
+  return move_count;
+}
 
 size_t king_moves(const chess_state_t* chess_state, move_t* moves,
-                  size_t move_count, sq0x88_t king_square, colour_t colour,
-                  enum generator_mode generation_mode) {
+                  size_t move_count, sq0x88_t king_square, colour_t colour) {
   for (int i = 0; i < KING_INCREMENTS_COUNT; i++) {
     sq0x88_t to = king_square + king_increments_list[i];
     if (off_the_board(to) || piece_is_colour(chess_state, to, colour)) {
       continue;
     }
     piece_t target_piece = piece(chess_state, to);
-    if (target_piece == EMPTY && (generation_mode & GENERATE_QUIETS)) {
+    if (target_piece == EMPTY) {
       moves[move_count++] = move(king_square, to, QUIET_MOVE);
-    } else if (target_piece != EMPTY && (generation_mode & GENERATE_CAPTURES)) {
+    } else if (target_piece != EMPTY) {
       moves[move_count++] = move(king_square, to, CAPTURE);
     }
   }
@@ -111,12 +125,41 @@ size_t king_moves(const chess_state_t* chess_state, move_t* moves,
   return move_count;
 }
 
-size_t castling_moves(const chess_state_t* chess_state, move_t* moves,
-                      size_t move_count, sq0x88_t king_square, colour_t colour,
-                      enum generator_mode generation_mode) {
-  if (!(generation_mode & GENERATE_QUIETS)) {
-    return move_count;
+size_t king_captures(const chess_state_t* chess_state, move_t* moves,
+                     size_t move_count, sq0x88_t king_square, colour_t colour) {
+  for (int i = 0; i < KING_INCREMENTS_COUNT; i++) {
+    sq0x88_t to = king_square + king_increments_list[i];
+    if (off_the_board(to) || piece_is_colour(chess_state, to, colour)) {
+      continue;
+    }
+    piece_t target_piece = piece(chess_state, to);
+    if (target_piece != EMPTY) {
+      moves[move_count++] = move(king_square, to, CAPTURE);
+    }
   }
+
+  return move_count;
+}
+
+size_t king_quiets(const chess_state_t* chess_state, move_t* moves,
+                   size_t move_count, sq0x88_t king_square, colour_t colour) {
+  for (int i = 0; i < KING_INCREMENTS_COUNT; i++) {
+    sq0x88_t to = king_square + king_increments_list[i];
+    if (off_the_board(to) || piece_is_colour(chess_state, to, colour)) {
+      continue;
+    }
+    piece_t target_piece = piece(chess_state, to);
+    if (target_piece == EMPTY) {
+      moves[move_count++] = move(king_square, to, QUIET_MOVE);
+    }
+  }
+
+  return move_count;
+}
+
+size_t castling_moves(const chess_state_t* chess_state, move_t* moves,
+                      size_t move_count, sq0x88_t king_square,
+                      colour_t colour) {
   // castling
   if (can_castle_king_side(chess_state, colour)) {
     moves[move_count++] = move(king_square, king_square + 2, KING_CASTLE);
@@ -126,10 +169,6 @@ size_t castling_moves(const chess_state_t* chess_state, move_t* moves,
   }
   return move_count;
 }
-
-
-
-
 
 // flags should either be QUIET_MOVE or CAPTURE, add_promotion_moves will handle
 // the promotion flags
@@ -143,16 +182,12 @@ size_t add_promotion_moves(move_t* moves, size_t move_count, sq0x88_t from,
 }
 
 size_t pawn_moves(const chess_state_t* chess_state, move_t* moves,
-                  size_t move_count, sq0x88_t from, colour_t colour,
-                  enum generator_mode generation_mode) {
+                  size_t move_count, sq0x88_t from, colour_t colour) {
   // if is promoting
   sq0x88_t inc = pawn_push_increment(colour);
   colour_t enemy_colour = opposite_colour(colour);
   sq0x88_t to = from + inc;
   if (is_promoting(from, colour)) {
-    if (!(generation_mode & GENERATE_PROMOTIONS)) {
-      return move_count;
-    }
     if (piece(chess_state, to) == EMPTY) {
       move_count = add_promotion_moves(moves, move_count, from, to, QUIET_MOVE);
     }
@@ -166,58 +201,114 @@ size_t pawn_moves(const chess_state_t* chess_state, move_t* moves,
     }
     return move_count;
   }
-  if (generation_mode & GENERATE_QUIETS) {
-    if (!off_the_board(to) && piece(chess_state, to) == EMPTY) {
-      moves[move_count++] = move(from, to, QUIET_MOVE);
-    }
-    to = from + 2 * inc;
-    if (!off_the_board(to) && piece(chess_state, to) == EMPTY &&
-        piece(chess_state, to - inc) == EMPTY &&
-        pawn_can_double_push(from, colour)) {
-      moves[move_count++] = move(from, to, DOUBLE_PAWN_PUSH);
-    }
+  if (!off_the_board(to) && piece(chess_state, to) == EMPTY) {
+    moves[move_count++] = move(from, to, QUIET_MOVE);
   }
-  if (generation_mode & GENERATE_CAPTURES) {
-    to = from + inc + 1;
-    if (!off_the_board(to) && piece_is_colour(chess_state, to, enemy_colour)) {
-      moves[move_count++] = move(from, to, CAPTURE);
-    }
-    to = from + inc - 1;
-    if (!off_the_board(to) && piece_is_colour(chess_state, to, enemy_colour)) {
-      moves[move_count++] = move(from, to, CAPTURE);
-    }
+  to = from + 2 * inc;
+  if (!off_the_board(to) && piece(chess_state, to) == EMPTY &&
+      piece(chess_state, to - inc) == EMPTY &&
+      pawn_can_double_push(from, colour)) {
+    moves[move_count++] = move(from, to, DOUBLE_PAWN_PUSH);
+  }
 
-    if (!off_the_board(enpassent_target(chess_state)) &&
-        can_capture_enpassent(chess_state, from, colour)) {
-      moves[move_count++] =
-          move(from, enpassent_target(chess_state), ENPASSENT);
-    }
+  to = from + inc + 1;
+  if (!off_the_board(to) && piece_is_colour(chess_state, to, enemy_colour)) {
+    moves[move_count++] = move(from, to, CAPTURE);
+  }
+  to = from + inc - 1;
+  if (!off_the_board(to) && piece_is_colour(chess_state, to, enemy_colour)) {
+    moves[move_count++] = move(from, to, CAPTURE);
+  }
+
+  if (!off_the_board(enpassent_target(chess_state)) &&
+      can_capture_enpassent(chess_state, from, colour)) {
+    moves[move_count++] = move(from, enpassent_target(chess_state), ENPASSENT);
   }
 
   return move_count;
 }
 
+size_t pawn_captures(const chess_state_t* chess_state, move_t* moves,
+                     size_t move_count, sq0x88_t from, colour_t colour) {
+  // if is promoting
+  sq0x88_t inc = pawn_push_increment(colour);
+  colour_t enemy_colour = opposite_colour(colour);
+  sq0x88_t to = from + inc;
+  if (is_promoting(from, colour)) {
+    return move_count;
+  }
+  to = from + inc + 1;
+  if (!off_the_board(to) && piece_is_colour(chess_state, to, enemy_colour)) {
+    moves[move_count++] = move(from, to, CAPTURE);
+  }
+  to = from + inc - 1;
+  if (!off_the_board(to) && piece_is_colour(chess_state, to, enemy_colour)) {
+    moves[move_count++] = move(from, to, CAPTURE);
+  }
 
+  if (!off_the_board(enpassent_target(chess_state)) &&
+      can_capture_enpassent(chess_state, from, colour)) {
+    moves[move_count++] = move(from, enpassent_target(chess_state), ENPASSENT);
+  }
 
+  return move_count;
+}
 
+size_t pawn_quiets(const chess_state_t* chess_state, move_t* moves,
+                   size_t move_count, sq0x88_t from, colour_t colour) {
+  // if is promoting
+  sq0x88_t inc = pawn_push_increment(colour);
+  colour_t enemy_colour = opposite_colour(colour);
+  sq0x88_t to = from + inc;
+  if (is_promoting(from, colour)) {
+    return move_count;
+  }
+  if (!off_the_board(to) && piece(chess_state, to) == EMPTY) {
+    moves[move_count++] = move(from, to, QUIET_MOVE);
+  }
+  to = from + 2 * inc;
+  if (!off_the_board(to) && piece(chess_state, to) == EMPTY &&
+      piece(chess_state, to - inc) == EMPTY &&
+      pawn_can_double_push(from, colour)) {
+    moves[move_count++] = move(from, to, DOUBLE_PAWN_PUSH);
+  }
+
+  return move_count;
+}
+
+size_t pawn_promotions(const chess_state_t* chess_state, move_t* moves,
+                       size_t move_count, sq0x88_t from, colour_t colour) {
+  // if is promoting
+  sq0x88_t inc = pawn_push_increment(colour);
+  colour_t enemy_colour = opposite_colour(colour);
+  sq0x88_t to = from + inc;
+  if (!is_promoting(from, colour)) {
+    return move_count;
+  }
+  if (piece(chess_state, to) == EMPTY) {
+    move_count = add_promotion_moves(moves, move_count, from, to, QUIET_MOVE);
+  }
+  to = from + inc + 1;
+  if (!off_the_board(to) && piece_is_colour(chess_state, to, enemy_colour)) {
+    move_count = add_promotion_moves(moves, move_count, from, to, CAPTURE);
+  }
+  to = from + inc - 1;
+  if (!off_the_board(to) && piece_is_colour(chess_state, to, enemy_colour)) {
+    move_count = add_promotion_moves(moves, move_count, from, to, CAPTURE);
+  }
+  return move_count;
+}
 
 size_t sliding_moves(const chess_state_t* chess_state, move_t* moves,
                      size_t move_count, sq0x88_t from, colour_t colour,
-                     enum generator_mode generation_mode,
                      const sq0x88_t* increments, int increments_count) {
   for (sq0x88_t i = 0; i < increments_count; i++) {
     sq0x88_t inc = increments[i];
     sq0x88_t to;
-    if (generation_mode & GENERATE_QUIETS) {
-      for (to = from + inc; piece(chess_state, to) == EMPTY; to += inc) {
-        moves[move_count++] = move(from, to, QUIET_MOVE);
-      }
-    } else {
-      to = forwards_ray_cast(chess_state, from, inc);
+    for (to = from + inc; piece(chess_state, to) == EMPTY; to += inc) {
+      moves[move_count++] = move(from, to, QUIET_MOVE);
     }
-    if (!(generation_mode & GENERATE_CAPTURES) || off_the_board(to) ||
-        piece_is_colour(chess_state, to, colour))
-      continue;
+    if (off_the_board(to) || piece_is_colour(chess_state, to, colour)) continue;
 
     moves[move_count++] = move(from, to, CAPTURE);
   }
@@ -225,28 +316,26 @@ size_t sliding_moves(const chess_state_t* chess_state, move_t* moves,
 }
 
 size_t sliding_quiets(const chess_state_t* chess_state, move_t* moves,
-                     size_t move_count, sq0x88_t from, colour_t colour,
-                     const sq0x88_t* increments, int increments_count) {
+                      size_t move_count, sq0x88_t from, colour_t colour,
+                      const sq0x88_t* increments, int increments_count) {
   (void)colour;
   for (sq0x88_t i = 0; i < increments_count; i++) {
     sq0x88_t inc = increments[i];
     sq0x88_t to;
-      for (to = from + inc; piece(chess_state, to) == EMPTY; to += inc) {
-        moves[move_count++] = move(from, to, QUIET_MOVE);
-      }
+    for (to = from + inc; piece(chess_state, to) == EMPTY; to += inc) {
+      moves[move_count++] = move(from, to, QUIET_MOVE);
+    }
   }
   return move_count;
 }
 
 size_t sliding_captures(const chess_state_t* chess_state, move_t* moves,
-                     size_t move_count, sq0x88_t from, colour_t colour,
-                     const sq0x88_t* increments, int increments_count) {
+                        size_t move_count, sq0x88_t from, colour_t colour,
+                        const sq0x88_t* increments, int increments_count) {
   for (sq0x88_t i = 0; i < increments_count; i++) {
     sq0x88_t inc = increments[i];
     sq0x88_t to = forwards_ray_cast(chess_state, from, inc);
-    if (off_the_board(to) ||
-        piece_is_colour(chess_state, to, colour))
-      continue;
+    if (off_the_board(to) || piece_is_colour(chess_state, to, colour)) continue;
 
     moves[move_count++] = move(from, to, CAPTURE);
   }
@@ -294,58 +383,146 @@ size_t sliding_captures(const chess_state_t* chess_state, move_t* moves,
   } while (0)
 
 size_t generate_moves_nocheck_internal(const chess_state_t* chess_state,
-                                       move_t* moves, colour_t colour,
-                                       enum generator_mode generation_mode) {
+                                       move_t* moves, colour_t colour) {
   size_t move_count = 0;
   const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
-  move_count =
-      castling_moves(chess_state, moves, move_count, piece_lists->king_square,
-                     colour, generation_mode);
+  move_count = castling_moves(chess_state, moves, move_count,
+                              piece_lists->king_square, colour);
 
   move_count = king_moves(chess_state, moves, move_count,
-                          piece_lists->king_square, colour, generation_mode);
+                          piece_lists->king_square, colour);
 
   FOR_EACH_PIECE(piece_lists, queen, square) {
     move_count = sliding_moves(chess_state, moves, move_count, square, colour,
-                               generation_mode, queen_increments_list,
-                               QUEEN_INCREMENTS_COUNT);
+                               queen_increments_list, QUEEN_INCREMENTS_COUNT);
   }
 
   FOR_EACH_PIECE(piece_lists, rook, square) {
     move_count = sliding_moves(chess_state, moves, move_count, square, colour,
-                               generation_mode, rook_increments_list,
-                               ROOK_INCREMENTS_COUNT);
+                               rook_increments_list, ROOK_INCREMENTS_COUNT);
   }
 
   FOR_EACH_PIECE(piece_lists, light_bishop, square) {
     move_count = sliding_moves(chess_state, moves, move_count, square, colour,
-                               generation_mode, bishop_increments_list,
-                               BISHOP_INCREMENTS_COUNT);
+                               bishop_increments_list, BISHOP_INCREMENTS_COUNT);
   }
 
   FOR_EACH_PIECE(piece_lists, dark_bishop, square) {
     move_count = sliding_moves(chess_state, moves, move_count, square, colour,
-                               generation_mode, bishop_increments_list,
-                               BISHOP_INCREMENTS_COUNT);
+                               bishop_increments_list, BISHOP_INCREMENTS_COUNT);
   }
 
   FOR_EACH_PIECE(piece_lists, knight, square) {
-    move_count = knight_moves(chess_state, moves, move_count, square, colour,
-                              generation_mode);
+    move_count = knight_moves(chess_state, moves, move_count, square, colour);
   }
 
   FOR_EACH_PIECE(piece_lists, pawn, square) {
-    move_count = pawn_moves(chess_state, moves, move_count, square, colour,
-                            generation_mode);
+    move_count = pawn_moves(chess_state, moves, move_count, square, colour);
   }
 
   return move_count;
 }
 
 
+size_t generate_captures_nocheck_internal(const chess_state_t* chess_state,
+                                          move_t* moves, colour_t colour) {
+  size_t move_count = 0;
+  const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
 
+  move_count = king_captures(chess_state, moves, move_count,
+                             piece_lists->king_square, colour);
 
+  FOR_EACH_PIECE(piece_lists, queen, square) {
+    move_count =
+        sliding_captures(chess_state, moves, move_count, square, colour,
+                         queen_increments_list, QUEEN_INCREMENTS_COUNT);
+  }
 
+  FOR_EACH_PIECE(piece_lists, rook, square) {
+    move_count =
+        sliding_captures(chess_state, moves, move_count, square, colour,
+                         rook_increments_list, ROOK_INCREMENTS_COUNT);
+  }
+
+  FOR_EACH_PIECE(piece_lists, light_bishop, square) {
+    move_count =
+        sliding_captures(chess_state, moves, move_count, square, colour,
+                         bishop_increments_list, BISHOP_INCREMENTS_COUNT);
+  }
+
+  FOR_EACH_PIECE(piece_lists, dark_bishop, square) {
+    move_count =
+        sliding_captures(chess_state, moves, move_count, square, colour,
+                         bishop_increments_list, BISHOP_INCREMENTS_COUNT);
+  }
+
+  FOR_EACH_PIECE(piece_lists, knight, square) {
+    move_count =
+        knight_captures(chess_state, moves, move_count, square, colour);
+  }
+
+  FOR_EACH_PIECE(piece_lists, pawn, square) {
+    move_count = pawn_captures(chess_state, moves, move_count, square, colour);
+  }
+
+  return move_count;
+}
+
+size_t generate_quiets_nocheck_internal(const chess_state_t* chess_state,
+                                        move_t* moves, colour_t colour) {
+  size_t move_count = 0;
+  const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
+  move_count = castling_moves(chess_state, moves, move_count,
+                              piece_lists->king_square, colour);
+
+  move_count = king_quiets(chess_state, moves, move_count,
+                           piece_lists->king_square, colour);
+
+  FOR_EACH_PIECE(piece_lists, queen, square) {
+    move_count = sliding_quiets(chess_state, moves, move_count, square, colour,
+                                queen_increments_list, QUEEN_INCREMENTS_COUNT);
+  }
+
+  FOR_EACH_PIECE(piece_lists, rook, square) {
+    move_count = sliding_quiets(chess_state, moves, move_count, square, colour,
+                                rook_increments_list, ROOK_INCREMENTS_COUNT);
+  }
+
+  FOR_EACH_PIECE(piece_lists, light_bishop, square) {
+    move_count =
+        sliding_quiets(chess_state, moves, move_count, square, colour,
+                       bishop_increments_list, BISHOP_INCREMENTS_COUNT);
+  }
+
+  FOR_EACH_PIECE(piece_lists, dark_bishop, square) {
+    move_count =
+        sliding_quiets(chess_state, moves, move_count, square, colour,
+                       bishop_increments_list, BISHOP_INCREMENTS_COUNT);
+  }
+
+  FOR_EACH_PIECE(piece_lists, knight, square) {
+    move_count = knight_quiets(chess_state, moves, move_count, square, colour);
+  }
+
+  FOR_EACH_PIECE(piece_lists, pawn, square) {
+    move_count = pawn_quiets(chess_state, moves, move_count, square, colour);
+  }
+
+  return move_count;
+}
+
+size_t generate_promotions_nocheck_internal(const chess_state_t* chess_state,
+                                            move_t* moves, colour_t colour) {
+  size_t move_count = 0;
+  const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
+
+  FOR_EACH_PIECE(piece_lists, pawn, square) {
+    move_count =
+        pawn_promotions(chess_state, moves, move_count, square, colour);
+  }
+
+  return move_count;
+}
 
 int sliding_can_reach(const chess_state_t* chess_state, sq0x88_t from,
                       sq0x88_t target, sq0x88_t inc) {
@@ -358,49 +535,47 @@ int sliding_can_capture(const chess_state_t* chess_state, sq0x88_t from,
 }
 
 size_t generate_captures_of(const chess_state_t* chess_state, move_t* moves,
-                            size_t move_count, colour_t colour, sq0x88_t target,
-                            enum generator_mode generation_mode) {
+                            size_t move_count, colour_t colour,
+                            sq0x88_t target) {
   const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
   // queen moves
-  if (generation_mode & GENERATE_CAPTURES) {
-    FOR_EACH_PIECE(piece_lists, queen, square) {
+  FOR_EACH_PIECE(piece_lists, queen, square) {
+    if (sliding_can_capture(chess_state, square, target,
+                            queen_increment(square, target))) {
+      moves[move_count++] = move(square, target, CAPTURE);
+    }
+  }
+
+  // rook moves
+  FOR_EACH_PIECE(piece_lists, rook, square) {
+    if (sliding_can_capture(chess_state, square, target,
+                            rook_increment(square, target))) {
+      moves[move_count++] = move(square, target, CAPTURE);
+    }
+  }
+
+  if (is_light_square(target)) {
+    // light bishop moves
+    FOR_EACH_PIECE(piece_lists, light_bishop, square) {
       if (sliding_can_capture(chess_state, square, target,
-                              queen_increment(square, target))) {
+                              bishop_increment(square, target))) {
         moves[move_count++] = move(square, target, CAPTURE);
       }
     }
-
-    // rook moves
-    FOR_EACH_PIECE(piece_lists, rook, square) {
+  } else {
+    // dark bishop moves
+    FOR_EACH_PIECE(piece_lists, dark_bishop, square) {
       if (sliding_can_capture(chess_state, square, target,
-                              rook_increment(square, target))) {
+                              bishop_increment(square, target))) {
         moves[move_count++] = move(square, target, CAPTURE);
       }
     }
+  }
 
-    if (is_light_square(target)) {
-      // light bishop moves
-      FOR_EACH_PIECE(piece_lists, light_bishop, square) {
-        if (sliding_can_capture(chess_state, square, target,
-                                bishop_increment(square, target))) {
-          moves[move_count++] = move(square, target, CAPTURE);
-        }
-      }
-    } else {
-      // dark bishop moves
-      FOR_EACH_PIECE(piece_lists, dark_bishop, square) {
-        if (sliding_can_capture(chess_state, square, target,
-                                bishop_increment(square, target))) {
-          moves[move_count++] = move(square, target, CAPTURE);
-        }
-      }
-    }
-
-    // knight moves
-    FOR_EACH_PIECE(piece_lists, knight, square) {
-      if (knight_increment(square, target)) {
-        moves[move_count++] = move(square, target, CAPTURE);
-      }
+  // knight moves
+  FOR_EACH_PIECE(piece_lists, knight, square) {
+    if (knight_increment(square, target)) {
+      moves[move_count++] = move(square, target, CAPTURE);
     }
   }
   // pawn captures
@@ -408,143 +583,160 @@ size_t generate_captures_of(const chess_state_t* chess_state, move_t* moves,
   sq0x88_t from;
   piece_t friendly_pawn = colour | PAWN;
   if (is_promoting(target - inc, colour)) {
-    if (generation_mode & GENERATE_PROMOTIONS) {
-      from = target - inc + 1;
-      if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
-        move_count =
-            add_promotion_moves(moves, move_count, from, target, CAPTURE);
-      }
-      from = target - inc - 1;
-      if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
-        move_count =
-            add_promotion_moves(moves, move_count, from, target, CAPTURE);
-      }
-    }
     return move_count;
   }
-  if (generation_mode & GENERATE_CAPTURES) {
-    from = target - inc + 1;
-    if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
-      moves[move_count++] = move(from, target, CAPTURE);
-    }
+  from = target - inc + 1;
+  if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
+    moves[move_count++] = move(from, target, CAPTURE);
+  }
 
-    from = target - inc - 1;
-    if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
-      moves[move_count++] = move(from, target, CAPTURE);
-    }
+  from = target - inc - 1;
+  if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
+    moves[move_count++] = move(from, target, CAPTURE);
+  }
 
-    if (enpassent_target(chess_state) == target + inc) {
-      from = target + 1;
-      if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn &&
-          can_capture_enpassent(chess_state, from, colour)) {
-        moves[move_count++] =
-            move(from, enpassent_target(chess_state), ENPASSENT);
-      }
-      from = target - 1;
-      if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn &&
-          can_capture_enpassent(chess_state, from, colour)) {
-        moves[move_count++] =
-            move(from, enpassent_target(chess_state), ENPASSENT);
-      }
+  if (enpassent_target(chess_state) == target + inc) {
+    from = target + 1;
+    if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn &&
+        can_capture_enpassent(chess_state, from, colour)) {
+      moves[move_count++] =
+          move(from, enpassent_target(chess_state), ENPASSENT);
+    }
+    from = target - 1;
+    if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn &&
+        can_capture_enpassent(chess_state, from, colour)) {
+      moves[move_count++] =
+          move(from, enpassent_target(chess_state), ENPASSENT);
     }
   }
   return move_count;
 }
 
-size_t generate_interposing_moves(const chess_state_t* chess_state,
-                                  move_t* moves, size_t move_count,
-                                  colour_t colour,
-                                  enum generator_mode generation_mode,
-                                  sq0x88_t start, sq0x88_t stop, sq0x88_t inc) {
+size_t generate_promotion_captures_of(const chess_state_t* chess_state,
+                                      move_t* moves, size_t move_count,
+                                      colour_t colour, sq0x88_t target) {
   const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
-  if (generation_mode & GENERATE_QUIETS) {
-    // queen moves
-    FOR_EACH_PIECE(piece_lists, queen, square) {
-      for (sq0x88_t target = start; target != stop; target += inc) {
-        if (sliding_can_reach(chess_state, square, target,
-                              queen_increment(square, target))) {
-          moves[move_count++] = move(square, target, QUIET_MOVE);
-        }
-      }
-    }
+  if (sq8x8_to_rank07(target) != backrank(colour)) {
+    return move_count;
+  }
+  sq0x88_t inc = pawn_push_increment(colour);
+  sq0x88_t from;
+  piece_t friendly_pawn = colour | PAWN;
+  from = target - inc + 1;
+  if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
+    move_count = add_promotion_moves(moves, move_count, from, target, CAPTURE);
+  }
+  from = target - inc - 1;
+  if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
+    move_count = add_promotion_moves(moves, move_count, from, target, CAPTURE);
+  }
 
-    // rook moves
-    FOR_EACH_PIECE(piece_lists, rook, square) {
-      for (sq0x88_t target = start; target != stop; target += inc) {
-        if (sliding_can_reach(chess_state, square, target,
-                              rook_increment(square, target))) {
-          moves[move_count++] = move(square, target, QUIET_MOVE);
-        }
-      }
-    }
-    // light bishop moves
-    FOR_EACH_PIECE(piece_lists, light_bishop, square) {
-      for (sq0x88_t target = start; target != stop; target += inc) {
-        if (is_light_square(target) &&
-            sliding_can_reach(chess_state, square, target,
-                              bishop_increment(square, target))) {
-          moves[move_count++] = move(square, target, QUIET_MOVE);
-        }
-      }
-    }
+  return move_count;
+}
 
-    // dark bishop moves
-    FOR_EACH_PIECE(piece_lists, dark_bishop, square) {
-      for (sq0x88_t target = start; target != stop; target += inc) {
-        if (is_dark_square(target) &&
-            sliding_can_reach(chess_state, square, target,
-                              bishop_increment(square, target))) {
-          moves[move_count++] = move(square, target, QUIET_MOVE);
-        }
-      }
-    }
-
-    // knight moves
-    FOR_EACH_PIECE(piece_lists, knight, square) {
-      for (sq0x88_t target = start; target != stop; target += inc) {
-        if (knight_increment(square, target)) {
-          moves[move_count++] = move(square, target, QUIET_MOVE);
-        }
-      }
-    }
+size_t generate_promotion_interposing_moves(const chess_state_t* chess_state,
+                                            move_t* moves, size_t move_count,
+                                            colour_t colour, sq0x88_t start,
+                                            sq0x88_t stop, sq0x88_t inc) {
+  if (sq0x88_to_rank07(start) != backrank(colour) ||
+      sq0x88_to_rank07(stop) != backrank(colour)) {
+    return move_count;
   }
   // pawn moves
   sq0x88_t pawn_inc = pawn_push_increment(colour);
   piece_t friendly_pawn = PAWN | colour;
   for (sq0x88_t target = start; target != stop; target += inc) {
     sq0x88_t from;
-    if (sq0x88_to_rank07(target) == 0 || sq0x88_to_rank07(target) == 7) {
-      from = target - pawn_inc;
-
-      if ((generation_mode & GENERATE_PROMOTIONS) && !off_the_board(from) &&
-          piece(chess_state, from) == friendly_pawn) {
-        move_count =
-            add_promotion_moves(moves, move_count, from, target, QUIET_MOVE);
-      }
-
-    } else if (generation_mode & GENERATE_QUIETS) {
-      from = target - pawn_inc;
-      // printf("from %d target %d\n", from, target);
-      if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
-        moves[move_count++] = move(from, target, QUIET_MOVE);
-      }
-      from = target - 2 * pawn_inc;
-      if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn &&
-          piece(chess_state, target - pawn_inc) == EMPTY &&
-          pawn_can_double_push(from, colour)) {
-        moves[move_count++] = move(from, target, DOUBLE_PAWN_PUSH);
-      }
+    from = target - pawn_inc;
+    if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
+      move_count =
+          add_promotion_moves(moves, move_count, from, target, QUIET_MOVE);
     }
   }
 
   return move_count;
 }
 
+size_t generate_interposing_moves(const chess_state_t* chess_state,
+                                  move_t* moves, size_t move_count,
+                                  colour_t colour, sq0x88_t start,
+                                  sq0x88_t stop, sq0x88_t inc) {
+  const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
+  // queen moves
+  FOR_EACH_PIECE(piece_lists, queen, square) {
+    for (sq0x88_t target = start; target != stop; target += inc) {
+      if (sliding_can_reach(chess_state, square, target,
+                            queen_increment(square, target))) {
+        moves[move_count++] = move(square, target, QUIET_MOVE);
+      }
+    }
+  }
 
+  // rook moves
+  FOR_EACH_PIECE(piece_lists, rook, square) {
+    for (sq0x88_t target = start; target != stop; target += inc) {
+      if (sliding_can_reach(chess_state, square, target,
+                            rook_increment(square, target))) {
+        moves[move_count++] = move(square, target, QUIET_MOVE);
+      }
+    }
+  }
+  // light bishop moves
+  FOR_EACH_PIECE(piece_lists, light_bishop, square) {
+    for (sq0x88_t target = start; target != stop; target += inc) {
+      if (is_light_square(target) &&
+          sliding_can_reach(chess_state, square, target,
+                            bishop_increment(square, target))) {
+        moves[move_count++] = move(square, target, QUIET_MOVE);
+      }
+    }
+  }
+
+  // dark bishop moves
+  FOR_EACH_PIECE(piece_lists, dark_bishop, square) {
+    for (sq0x88_t target = start; target != stop; target += inc) {
+      if (is_dark_square(target) &&
+          sliding_can_reach(chess_state, square, target,
+                            bishop_increment(square, target))) {
+        moves[move_count++] = move(square, target, QUIET_MOVE);
+      }
+    }
+  }
+
+  // knight moves
+  FOR_EACH_PIECE(piece_lists, knight, square) {
+    for (sq0x88_t target = start; target != stop; target += inc) {
+      if (knight_increment(square, target)) {
+        moves[move_count++] = move(square, target, QUIET_MOVE);
+      }
+    }
+  }
+  if (sq0x88_to_rank07(start) == backrank(colour) &&
+      sq0x88_to_rank07(stop) == backrank(colour)) {
+    return move_count;
+  }
+  // pawn moves
+  sq0x88_t pawn_inc = pawn_push_increment(colour);
+  piece_t friendly_pawn = PAWN | colour;
+  for (sq0x88_t target = start; target != stop; target += inc) {
+    sq0x88_t from;
+    from = target - pawn_inc;
+    if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn) {
+      moves[move_count++] = move(from, target, QUIET_MOVE);
+    }
+    from = target - 2 * pawn_inc;
+    if (!off_the_board(from) && piece(chess_state, from) == friendly_pawn &&
+        piece(chess_state, target - pawn_inc) == EMPTY &&
+        pawn_can_double_push(from, colour)) {
+      moves[move_count++] = move(from, target, DOUBLE_PAWN_PUSH);
+    }
+  }
+
+  return move_count;
+}
 
 size_t generate_moves_check_internal(const chess_state_t* chess_state,
-                                     move_t* moves, colour_t colour,
-                                     enum generator_mode generation_mode) {
+                                     move_t* moves, colour_t colour) {
   // if more than 1 attacker, only king moves
   // if only 1 attacker, capture of attacker, block of attacker, king moves
   size_t move_count = 0;
@@ -552,8 +744,7 @@ size_t generate_moves_check_internal(const chess_state_t* chess_state,
 
   sq0x88_t king_square = piece_lists->king_square;
 
-  move_count = king_moves(chess_state, moves, move_count, king_square, colour,
-                          generation_mode);
+  move_count = king_moves(chess_state, moves, move_count, king_square, colour);
 
   if (is_double_check(chess_state)) {
     return move_count;
@@ -561,67 +752,160 @@ size_t generate_moves_check_internal(const chess_state_t* chess_state,
 
   piece_t checking_piece = piece(chess_state, checking_square(chess_state));
 
-  if (generation_mode & (GENERATE_CAPTURES | GENERATE_PROMOTIONS)) {
-    move_count =
-        generate_captures_of(chess_state, moves, move_count, colour,
-                             checking_square(chess_state), generation_mode);
-  }
+  move_count = generate_captures_of(chess_state, moves, move_count, colour,
+                                    checking_square(chess_state));
+  move_count = generate_promotion_captures_of(
+      chess_state, moves, move_count, colour, checking_square(chess_state));
+
   // if checking piece isn't a sliding piece cant be interposed
   if (!(checking_piece & (BISHOP | ROOK | QUEEN))) {
     return move_count;
   }
-  if (!(generation_mode & (GENERATE_QUIETS | GENERATE_PROMOTIONS))) {
-    return move_count;
-  }
+
   sq0x88_t inc = queen_increment(king_square, checking_square(chess_state));
-  move_count = generate_interposing_moves(
-      chess_state, moves, move_count, colour, generation_mode,
-      king_square + inc, checking_square(chess_state), inc);
+  move_count = generate_interposing_moves(chess_state, moves, move_count,
+                                          colour, king_square + inc,
+                                          checking_square(chess_state), inc);
+  move_count = generate_promotion_interposing_moves(
+      chess_state, moves, move_count, colour, king_square + inc,
+      checking_square(chess_state), inc);
 
   return move_count;
 }
 
+size_t generate_captures_check_internal(const chess_state_t* chess_state,
+                                     move_t* moves, colour_t colour) {
+  // if more than 1 attacker, only king moves
+  // if only 1 attacker, capture of attacker, block of attacker, king moves
+  size_t move_count = 0;
+  const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
 
+  sq0x88_t king_square = piece_lists->king_square;
 
+  move_count = king_captures(chess_state, moves, move_count, king_square, colour);
 
-
-size_t generate_moves_internal(const chess_state_t* chess_state, move_t* moves,
-                               colour_t colour,
-                               enum generator_mode generation_mode) {
-  size_t move_count;
-
-  if (is_check(chess_state)) {
-    move_count = generate_moves_check_internal(chess_state, moves, colour,
-                                               generation_mode);
-  } else {
-    move_count = generate_moves_nocheck_internal(chess_state, moves, colour,
-                                                 generation_mode);
+  if (is_double_check(chess_state)) {
+    return move_count;
   }
+
+  piece_t checking_piece = piece(chess_state, checking_square(chess_state));
+
+  move_count = generate_captures_of(chess_state, moves, move_count, colour,
+                                    checking_square(chess_state));
+
+  return move_count;
+}
+
+size_t generate_quiets_check_internal(const chess_state_t* chess_state,
+                                     move_t* moves, colour_t colour) {
+  // if more than 1 attacker, only king moves
+  // if only 1 attacker, capture of attacker, block of attacker, king moves
+  size_t move_count = 0;
+  const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
+
+  sq0x88_t king_square = piece_lists->king_square;
+
+  move_count = king_quiets(chess_state, moves, move_count, king_square, colour);
+
+  if (is_double_check(chess_state)) {
+    return move_count;
+  }
+
+  piece_t checking_piece = piece(chess_state, checking_square(chess_state));
+  // if checking piece isn't a sliding piece cant be interposed
+  if (!(checking_piece & (BISHOP | ROOK | QUEEN))) {
+    return move_count;
+  }
+
+  sq0x88_t inc = queen_increment(king_square, checking_square(chess_state));
+  move_count = generate_interposing_moves(chess_state, moves, move_count,
+                                          colour, king_square + inc,
+                                          checking_square(chess_state), inc);
+
+  return move_count;
+}
+
+size_t generate_promotions_check_internal(const chess_state_t* chess_state,
+                                     move_t* moves, colour_t colour) {
+  // if more than 1 attacker, only king moves
+  // if only 1 attacker, capture of attacker, block of attacker, king moves
+  size_t move_count = 0;
+  const piece_list_t* piece_lists = get_piece_list(chess_state, colour);
+
+  sq0x88_t king_square = piece_lists->king_square;
+
+  if (is_double_check(chess_state)) {
+    return move_count;
+  }
+
+  piece_t checking_piece = piece(chess_state, checking_square(chess_state));
+
+  move_count = generate_promotion_captures_of(
+      chess_state, moves, move_count, colour, checking_square(chess_state));
+
+  // if checking piece isn't a sliding piece cant be interposed
+  if (!(checking_piece & (BISHOP | ROOK | QUEEN))) {
+    return move_count;
+  }
+
+  sq0x88_t inc = queen_increment(king_square, checking_square(chess_state));
+
+  move_count = generate_promotion_interposing_moves(
+      chess_state, moves, move_count, colour, king_square + inc,
+      checking_square(chess_state), inc);
 
   return move_count;
 }
 
 size_t generate_moves(const chess_state_t* chess_state, move_t* moves,
-                      colour_t colour) {
-  return generate_moves_internal(chess_state, moves, colour, GENERATE_ALL);
+                               colour_t colour) {
+  size_t move_count;
+
+  if (is_check(chess_state)) {
+    move_count = generate_moves_check_internal(chess_state, moves, colour);
+  } else {
+    move_count = generate_moves_nocheck_internal(chess_state, moves, colour);
+  }
+
+  return move_count;
 }
+
 size_t generate_captures(const chess_state_t* chess_state, move_t* moves,
                          colour_t colour) {
-  return generate_moves_internal(chess_state, moves, colour, GENERATE_CAPTURES);
+  size_t move_count;
+
+  if (is_check(chess_state)) {
+    move_count = generate_captures_check_internal(chess_state, moves, colour);
+  } else {
+    move_count = generate_captures_nocheck_internal(chess_state, moves, colour);
+  }
+
+  return move_count;
 }
 size_t generate_quiets(const chess_state_t* chess_state, move_t* moves,
                        colour_t colour) {
-  return generate_moves_internal(chess_state, moves, colour, GENERATE_QUIETS);
+  size_t move_count;
+
+  if (is_check(chess_state)) {
+    move_count = generate_quiets_check_internal(chess_state, moves, colour);
+  } else {
+    move_count = generate_quiets_nocheck_internal(chess_state, moves, colour);
+  }
+
+  return move_count;
 }
 size_t generate_promotions(const chess_state_t* chess_state, move_t* moves,
                            colour_t colour) {
-  return generate_moves_internal(chess_state, moves, colour,
-                                 GENERATE_PROMOTIONS);
+  size_t move_count;
+
+  if (is_check(chess_state)) {
+    move_count = generate_promotions_check_internal(chess_state, moves, colour);
+  } else {
+    move_count = generate_promotions_nocheck_internal(chess_state, moves, colour);
+  }
+
+  return move_count;
 }
-
-
-
-
 
 size_t remove_illegal_moves(const chess_state_t* chess_state, move_t* moves,
                             size_t move_count) {
@@ -656,4 +940,3 @@ size_t generate_legal_promotions(const chess_state_t* chess_state,
   return remove_illegal_moves(chess_state, moves,
                               generate_promotions(chess_state, moves, colour));
 }
-

--- a/src/piece_list.c
+++ b/src/piece_list.c
@@ -51,6 +51,7 @@ void remove_piece(chess_state_t* chess_state, sq0x88_t target) {
       pl_remove(pl->queen_list, pl->queen_count, pl->indices_list, index);
       break;
     default:
+    trace_ply_stack(chess_state);
       assert(0 && "invalid piece code");
       break;
   }


### PR DESCRIPTION
Remove the generation mode enum.
Split generation functions into 3/4 variants.
- generate_moves
- generate_captures
- generate_quiets
- generate_promotions

Manually branched the generation functions to reduce branch misses and simplify the logic.
In investigations on Godbolt.org, it was observed that the manually branched functions used fewer instructions, for some, such as king moves, knight moves, and sliding moves it was as much as 2 to 3 times.
After further investigations with callgrind and after timing the execution time of /build/profTest several times it can be shown conclusively that this change improves performance.

| Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Avg | Stdev |
|--------|--------|--------|--------|--------|--------|--------|
| 4.554 | 4.135 | 4.134 | 4.158 | 4.227 | 4.24 | 0.18 |
| 3.07   | 2.996 | 2.997 | 2.962 | 3.021 | 3.01 | 0.04 |
